### PR TITLE
fix: broken paths when creating icons in Win32

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "lodash.foreach": "^4.5.0",
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
+    "slash": "^1.0.0",
     "svgo": "^0.7.2"
   },
   "devDependencies": {

--- a/src/build-icons.js
+++ b/src/build-icons.js
@@ -7,6 +7,7 @@ const esformatter = require('esformatter');
 const forEach = require('lodash.foreach');
 const camelCase = require('lodash.camelcase');
 const optimizeSVG = require('./svg-optimizer');
+const slash = require('slash');
 esformatter.register(require('esformatter-jsx'));
 
 let components = {};
@@ -71,7 +72,7 @@ function toReactAttributes($el, $) {
 
 createReactComponents = co.wrap(function* (svgPath, outputDir) {
   const name = path.basename(svgPath, '.svg');
-  const location = path.join(componentsDirName, name + '.js');
+  const location = slash(path.join(componentsDirName, name + '.js'));
   try {
     let svg = fs.readFileSync(svgPath, 'utf-8');
     svg = yield optimizeSVG(svg);
@@ -79,7 +80,7 @@ createReactComponents = co.wrap(function* (svgPath, outputDir) {
 
     components[name] = location;
 
-    fs.writeFileSync(path.join(outputDir, location), component, 'utf-8');
+    fs.writeFileSync(slash(path.join(outputDir, location), component, 'utf-8'));
     console.log(`created: ${path.join('.', location)}`);
   } catch (err) {
     console.error(`failed to create svg file for ${name}; Error: ${err}`);
@@ -100,7 +101,7 @@ import Icon from '../Icon';
 
 /*eslint-disable */
 const ${name} = props => (
-  <Icon viewBox="${viewBox}" {...props}>   
+  <Icon viewBox="${viewBox}" {...props}>
     <g>${iconSvg}</g>
   </Icon>
 );


### PR DESCRIPTION
Added [slash](https://www.npmjs.com/package/slash) NPM package for *backslash-to-slash* conversions on Windows. Without this workaround the generation of **src/Icons/Index.js** with **wix-style-react** would produce paths like 

```typescript
export {default as Chat} from './components\Chat';
``` 

Such paths wouldn't be processed correctly on Windows. 

In fact the above backslash would be ignored and storyboard generation would stumble upon something like this: 

```typescript
export {default as Chat} from './componentsChat';
``` 

Therefore, I'd recommend to keep the slashes by using the [slash package](https://github.com/sindresorhus/slash)

I don't know if Windows platform is one of your target architectures but I could at least generate a working storyboard after having applied this patch. **Macs** are too expensive for me 😅 

Feel free to ignore this PR. 

Kind regards,