### PR TITLE
fix(svgo): remove `<title>` elements

### DIFF
--- a/src/lib/svg-optimizer.js
+++ b/src/lib/svg-optimizer.js
@@ -1,6 +1,9 @@
 const SVGO = require('svgo');
 const svgo = new SVGO({
-  plugins: [{removeStyleElement: {}}]
+  plugins: [
+    {removeStyleElement: {}},
+    {removeTitle: true}
+  ]
 });
 
 const optimizeAsync = svgContent => {


### PR DESCRIPTION
svgo version below 1.0.0 does not enable `removeTitle` plugin by default
`<title>`s make unexpected OS tooltip to show up

upgrading svgo to 1.0.0 requires more changes