### PR TITLE
Removed unused propTypes

### DIFF
--- a/src/icon-base/Icon.tsx
+++ b/src/icon-base/Icon.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import * as PropTypes from 'prop-types';
 
 export interface IconProps extends React.SVGAttributes<SVGElement> {
   size?: string;


### PR DESCRIPTION
Removed unused propTypes which gave typescript error 'PropTypes' is declared but its value is never read.
