### PR TITLE
feat(build-icons): add `displayName` to js & ts

### DIFF
--- a/src/lib/svg2component.js
+++ b/src/lib/svg2component.js
@@ -31,6 +31,7 @@ module.exports = (name, svg, isTypeScriptOutput) => {
           ${children}
         </svg>
       );
+      ${name}.displayName = '${name}';
       export default ${name};
     ` :
     `
@@ -47,6 +48,7 @@ module.exports = (name, svg, isTypeScriptOutput) => {
           ${children}
         </svg>
       );
+      ${name}.displayName = '${name}';
       ${name}.propTypes = {
         size: PropTypes.string
       }

--- a/test/build-icons.spec.js
+++ b/test/build-icons.spec.js
@@ -226,5 +226,33 @@ describe('Build icons', () => {
         expectIconFiles(file1);
       });
     });
+
+    describe('`displayName`', () => {
+      it('should be included in javascript', () => {
+        const file1 = {
+          name: 'IAmTheOneWhoKnocks',
+          raw: `<svg viewBox="0 0 24 24"><polygon points="12"/></svg>`,
+          expected: /IAmTheOneWhoKnocks.displayName = 'IAmTheOneWhoKnocks';/
+        };
+        withSvgFiles(file1);
+
+        return buildIcons({inputDir, outputDir}).then(() => {
+          expectIconFiles(file1);
+        });
+      });
+
+      it('should be included in typescript', () => {
+        const file1 = {
+          name: 'IAmTheOneWhoTypes',
+          raw: `<svg viewBox="0 0 24 24"><polygon points="12"/></svg>`,
+          expected: /IAmTheOneWhoTypes.displayName = 'IAmTheOneWhoTypes';/
+        };
+        withSvgFiles(file1);
+
+        return buildIcons({inputDir, outputDir, typescript: true}).then(() => {
+          expectTypeScriptIconFiles(file1);
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
without `displayName` it is hard to document components that use icons.
Since icons become anonymous functions, it's impossible to know what
their names are. Automated documentation tools then rely on displaying
the source of icon which is not something useful for the consumer.

In picture (look at `prefixIcon` prop)

without `displayName`, when name of component is unknown just by looking at its source:
![2018-07-02-131537_screenshot](https://user-images.githubusercontent.com/4284659/42158771-21af31fa-7dfa-11e8-8623-3d966bd98842.png)

with `displayName` when there is a clear way to get the name
![2018-07-02-131546_screenshot](https://user-images.githubusercontent.com/4284659/42158791-2e1da3ea-7dfa-11e8-9881-4bb433853e0e.png)

in general this is not a harmful addition imo