### PR TITLE
disable cleanupIDs

### DIFF
--- a/src/lib/svg-optimizer.js
+++ b/src/lib/svg-optimizer.js
@@ -4,7 +4,8 @@ const svgo = new SVGO({
   plugins: [
     {removeViewBox: false},
     {removeStyleElement: true},
-    {removeScriptElement: true}
+    {removeScriptElement: true},
+    {cleanupIDs: false}
   ]
 });
 
@@ -13,6 +14,7 @@ const svgoMonochrome = new SVGO({
     {removeViewBox: false},
     {removeStyleElement: true},
     {removeScriptElement: true},
+    {cleanupIDs: false},
     {removeAttrs: {attrs: '(stroke|fill)'}}
   ]
 });


### PR DESCRIPTION
this fix the case where you have multiple svgs with ids, so they won't have they right id and clash with each other.