### PR TITLE
Fixed missing argument in call to new version of `SVGO.optimize`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "lodash.camelcase": "^4.3.0",
     "lodash.foreach": "^4.5.0",
     "prop-types": "^15.5.4",
-    "svgo": "^1.0.5"
+    "svgo": "^1.1.0"
   },
   "devDependencies": {
     "@types/react": "^15.6.15",

--- a/src/lib/svg-optimizer.js
+++ b/src/lib/svg-optimizer.js
@@ -19,7 +19,7 @@ const svgoMonochrome = new SVGO({
   ]
 });
 
-module.exports = (svgString, monochrome) =>
+module.exports = (svgString, monochrome, info = {}) =>
   (monochrome ? svgoMonochrome : svgo)
-    .optimize(svgString, {})
+    .optimize(svgString, info)
     .then(result => result.data);

--- a/src/lib/svg-optimizer.js
+++ b/src/lib/svg-optimizer.js
@@ -21,5 +21,5 @@ const svgoMonochrome = new SVGO({
 
 module.exports = (svgString, monochrome) =>
   (monochrome ? svgoMonochrome : svgo)
-    .optimize(svgString)
+    .optimize(svgString, {})
     .then(result => result.data);


### PR DESCRIPTION
After SVGO published their `1.1.0` update, the call to `optimize` expects an `info` argument which, if left `undefined`, causes an exception during the svg2react-icon process.

Yet, because of the previous `"svgo": "^1.0.5"` specification in `package.json`, the update reached various projects depending on this tool.

This PR passes an empty object instead of undefined, thus solving the exception.
