### PR TITLE
Add eslint & tslint disable annotation to the generated index file

### DIFF
--- a/src/build-icons.js
+++ b/src/build-icons.js
@@ -45,9 +45,16 @@ async function processIcon(svgPath, outputDir, options) {
 }
 
 function createIndexFile(componentNames, outputDir, options) {
-  const code = componentNames.map(name =>
-    `export {${options.namedExport ? '' : 'default as '}${name}} from './${componentsDirName}/${name}';`
-  ).join('\n') + '\n';
+  const code = componentNames.length ? [
+    '/* eslint-disable */',
+    '/* tslint:disable */',
+    componentNames.map(name =>
+      `export {${options.namedExport ? '' : 'default as '}${name}} from './${componentsDirName}/${name}';`
+    ).join('\n'),
+    '/* tslint:enable */',
+    '/* eslint-enable */',
+    ''
+  ].join('\n') : '\n';
 
   const filename = 'index' + (options.isTypeScriptOutput ? '.ts' : '.js');
   fs.writeFileSync(path.join(outputDir, filename), code, 'utf-8');

--- a/test/build-icons.spec.js
+++ b/test/build-icons.spec.js
@@ -80,6 +80,15 @@ describe('Build icons', () => {
         indexJs += `export {default as ${val.name}} from './components/${val.name}';\n`;
       }
     });
+
+    if (indexJs) {
+      indexJs = '/* eslint-disable */\n' +
+        '/* tslint:disable */\n' +
+        indexJs +
+        '/* tslint:enable */\n' +
+        '/* eslint-enable */\n';
+    }
+
     const regexp = new RegExp(`.*/dist/index.${options.typescript ? 'ts' : 'js'}$`);
     expect(fsMock.writeFileSync.mock.calls[totalFileWriteCount - 1][0]).toMatch(regexp);
     expect(fsMock.writeFileSync.mock.calls[totalFileWriteCount - 1][1]).toEqual(indexJs || '\n');


### PR DESCRIPTION
Whenever we have a project with prettier or some sort of lint rule that doesn't like the generated index file, we have a breaking build.

This is especially frustrating in yoshi + TypeScript project where tslint points to whatever TypeScript thinks is involved (included) in our project, which means that as long as we're importing from the index file - it's included and WILL be linted.
One of our project solved this by not importing from the index file but this should make it possible again.