### PR TITLE
Disable convertPathData optimization

### DIFF
--- a/src/lib/svg-optimizer.js
+++ b/src/lib/svg-optimizer.js
@@ -5,7 +5,8 @@ const svgo = new SVGO({
     {removeViewBox: false},
     {removeStyleElement: true},
     {removeScriptElement: true},
-    {cleanupIDs: false}
+    {cleanupIDs: false},
+    {convertPathData: false}
   ]
 });
 
@@ -15,7 +16,8 @@ const svgoMonochrome = new SVGO({
     {removeStyleElement: true},
     {removeScriptElement: true},
     {cleanupIDs: false},
-    {removeAttrs: {attrs: '(stroke|fill)'}}
+    {removeAttrs: {attrs: '(stroke|fill)'}},
+    {convertPathData: false}
   ]
 });
 


### PR DESCRIPTION
Disable the `convertPathData` svg optimization.

Such optimization may distort the path.

### Breaking change?
- `svg2react-icon` is an open source.
- According to `npm` there are 2 dependents on this project, but it doesn't show them. (I guess `wix-ui` is one of them).
- So... I am not concerned about being "impolite" for consumers of this package.
- In any way, even if this optimization was optional, the default would be to disable it.


Resolves https://github.com/wix/wix-style-react/issues/2576