### PR TITLE
fix --no-sub-dir option + add e2e tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ target
 maven
 .idea
 .history
+test/output

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@types/react": "^15.6.15",
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
+    "rimraf": "^3.0.2",
     "yoshi": "^2.1.5"
   },
   "jest": {

--- a/src/build-icons.js
+++ b/src/build-icons.js
@@ -7,15 +7,15 @@ const optimizeSvg = require('./lib/svg-optimizer');
 const COMPONENTS_DIR_NAME = 'components';
 
 function getIconsPath(outputDir, options) {
-  return options.noSubDir ? outputDir : path.join(outputDir, COMPONENTS_DIR_NAME);
+  return options.subDir ? path.join(outputDir, COMPONENTS_DIR_NAME) : outputDir;
 }
 
-module.exports = ({inputDir, outputDir, typescript, monochrome, namedExport, keepColors, noSubDir}) => {
+module.exports = ({inputDir, outputDir, typescript, monochrome, namedExport, keepColors, subDir}) => {
   if (!inputDir || !outputDir) {
     throw new Error('Input and output dirs not specified');
   }
   const icons = glob.sync(`${inputDir}/**/*.svg`);
-  return processIcons(icons, outputDir, {isTypeScriptOutput: typescript, monochrome, namedExport, keepColors, noSubDir});
+  return processIcons(icons, outputDir, {isTypeScriptOutput: typescript, monochrome, namedExport, keepColors, subDir});
 };
 
 async function processIcons(filenames, outputDir, options) {
@@ -52,7 +52,7 @@ function createIndexFile(componentNames, outputDir, options) {
     '/* eslint-disable */',
     '/* tslint:disable */',
     componentNames.map(name =>
-      `export {${options.namedExport ? '' : 'default as '}${name}} from '.${options.noSubDir ? '' : `/${COMPONENTS_DIR_NAME}`}/${name}';`
+      `export {${options.namedExport ? '' : 'default as '}${name}} from '.${options.subDir ? `/${COMPONENTS_DIR_NAME}` : ''}/${name}';`
     ).join('\n'),
     '/* tslint:enable */',
     '/* eslint-enable */',

--- a/src/lib/parse-params.js
+++ b/src/lib/parse-params.js
@@ -16,5 +16,5 @@ module.exports = {
   typescript: Boolean(program.typescript),
   namedExport: Boolean(program.namedExport),
   keepColors: Boolean(program.keepColors),
-  noSubDir: Boolean(program.noSubDir)
+  subDir: Boolean(program.subDir)
 };

--- a/test/build-icons.spec.js
+++ b/test/build-icons.spec.js
@@ -63,7 +63,7 @@ describe('Build icons', () => {
     svgFiles.forEach((val, index) => {
       const filePath = fsMock.writeFileSync.mock.calls[index][0];
       const fileContent = fsMock.writeFileSync.mock.calls[index][1];
-      const subDir = options.noSubDir ? '' : '/components';
+      const subDir = options.subDir ? '/components' : '';
       const regexp = new RegExp(`${subDir}/${val.name}.${options.typescript ? 'ts' : 'js'}`);
 
       expect(filePath).toMatch(regexp);
@@ -326,8 +326,8 @@ describe('Build icons', () => {
       };
       withSvgFiles(file1);
 
-      return buildIcons({inputDir, outputDir, noSubDir: true}).then(() => {
-        expectIconFiles([file1], {noSubDir: true});
+      return buildIcons({inputDir, outputDir, subDir: false}).then(() => {
+        expectIconFiles([file1], {subDir: false});
       });
     });
   });

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -96,7 +96,7 @@ describe('index', () => {
   });
 
   describe('--no-sub-dir', () => {
-    it('should create file with named export', done => {
+    it('should create file in output dir, without "components" sub dir', done => {
       spawnSync('node', createCommand(['--no-sub-dir']));
       const filePath = path.resolve('.', OUTPUT_FILE, 'test.js');
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,0 +1,113 @@
+import rimraf from 'rimraf';
+
+const {spawnSync} = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const OUTPUT_FILE = 'test/output';
+
+function createCommand(options = []) {
+  return `./src/index.js ${options.join(' ')} test/svgs ${OUTPUT_FILE}`.split(' ');
+}
+
+function clean() {
+  return new Promise((res, rej) => {
+    rimraf(path.resolve('.', `${OUTPUT_FILE}/*`), err => {
+      if (err) {
+        rej(err);
+      } else {
+        res();
+      }
+    });
+  });
+}
+
+describe('index', () => {
+  const filePath = path.resolve('.', OUTPUT_FILE, 'components/test.js');
+  const tsFilePath = path.resolve('.', OUTPUT_FILE, 'components/test.tsx');
+
+  beforeAll(async () => {
+    await clean();
+  });
+
+  afterEach(async () => {
+    await clean();
+  });
+
+  describe('--typescript', () => {
+    it('should create typescript file', done => {
+      const spawnedProcess = spawnSync('node', createCommand(['--typescript']));
+
+      fs.readFile(tsFilePath, {encoding: 'utf-8'}, (err, data) => {
+        if (!err) {
+          expect(data).toBeTruthy();
+        } else {
+          expect(true).toBeFalsy();
+        }
+        done();
+      });
+      expect(spawnedProcess.output.toString()).toContain('Created: test/output/components/test.tsx');
+    });
+  });
+
+  describe('--monochrome', () => {
+    it('should strip out fills', done => {
+      spawnSync('node', createCommand(['--monochrome']));
+
+      fs.readFile(filePath, {encoding: 'utf-8'}, (err, data) => {
+        if (!err) {
+          expect(data.replace(/fill="currentColor"/g, '').indexOf('fill=')).toBe(-1);
+        } else {
+          expect(true).toBeFalsy();
+        }
+        done();
+      });
+    });
+  });
+
+  describe('--keep-colors', () => {
+    it('should strip out fills', done => {
+      spawnSync('node', createCommand(['--keep-colors']));
+
+      fs.readFile(filePath, {encoding: 'utf-8'}, (err, data) => {
+        if (!err) {
+          expect(data.replace(/fill="currentColor"/g, '').indexOf('fill="green"')).toBeGreaterThan(-1);
+        } else {
+          expect(true).toBeFalsy();
+        }
+        done();
+      });
+    });
+  });
+
+  describe('--named-export', () => {
+    it('should create file with named export', done => {
+      spawnSync('node', createCommand(['--named-export']));
+
+      fs.readFile(filePath, {encoding: 'utf-8'}, (err, data) => {
+        if (!err) {
+          expect(data.indexOf('export const test')).toBeGreaterThan(-1);
+        } else {
+          expect(true).toBeFalsy();
+        }
+        done();
+      });
+    });
+  });
+
+  describe('--no-sub-dir', () => {
+    it('should create file with named export', done => {
+      spawnSync('node', createCommand(['--no-sub-dir']));
+      const filePath = path.resolve('.', OUTPUT_FILE, 'test.js');
+
+      fs.readFile(filePath, {encoding: 'utf-8'}, (err, data) => {
+        if (!err) {
+          expect(data).toBeTruthy();
+        } else {
+          expect(true).toBeFalsy();
+        }
+        done();
+      });
+    });
+  });
+});

--- a/test/svgs/test.svg
+++ b/test/svgs/test.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>09 Icons / Check / Regular Copy</title>
+    <desc>Created with Sketch.</desc>
+    <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g transform="translate(5.000000, 7.000000)" fill="green" fill-rule="nonzero">
+            <polygon points="13.3 0 14 0.7 5.3 10 0 5.8 0.6 5 5.2 8.7"></polygon>
+        </g>
+    </g>
+</svg>


### PR DESCRIPTION
Apparently, negating an option (i.e. starting with `--no`),
creates a property without the `no` prefix.

Meaning instead of using `noSubDir` I should have used `subDir`.

See `commander`'s documentation for more info:
https://github.com/tj/commander.js#other-option-types-negatable-boolean-and-flagvalue