### PR TITLE
Fix generated types

### DIFF
--- a/src/lib/svg2component.js
+++ b/src/lib/svg2component.js
@@ -19,9 +19,9 @@ module.exports = (name, svg, options) => {
     `
       import * as React from 'react';
       export interface ${name}Props extends React.SVGAttributes<SVGElement> {
-        size?: string;
+        size?: string | number;
       }
-      ${options.namedExport ? 'export ' : ''}const ${name}: React.SFC<${name}Props> = ({size, ...props}) => (
+      ${options.namedExport ? 'export ' : ''}const ${name}: React.FC<${name}Props> = ({size, ...props}) => (
         <svg
           ${viewBox}
           fill="currentColor"


### PR DESCRIPTION
`size` property type should be the same as React.SVGAttributes<SVGSVGElement>.width and React.SVGAttributes<SVGSVGElement>.height which are types as `number | string`.

Also React.SFC has been [deprecated](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/30364), we should use React.FC instead